### PR TITLE
Refactor receiver metrics.

### DIFF
--- a/factory.go
+++ b/factory.go
@@ -45,7 +45,7 @@ func createMetricsReceiver(
 		return nil, err
 	}
 
-	r := newOxideScraper(rCfg, settings.Logger, client)
+	r := newOxideScraper(rCfg, settings.TelemetrySettings, client)
 	s, err := scraper.NewMetrics(r.Scrape, scraper.WithStart(r.Start), scraper.WithShutdown(r.Shutdown))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In addition to metrics received from the Oxide api, the receiver also exposes metrics about its own functioning. This patch refactors those metrics to use the otel sdk, and adds new metrics for overall scrape duration and count.