### PR TITLE
feat: optionally add human-readable labels.

### DIFF
--- a/config.go
+++ b/config.go
@@ -14,6 +14,9 @@ type Config struct {
 	Token             string   `mapstructure:"token"`
 	MetricPatterns    []string `mapstructure:"metric_patterns"`
 	ScrapeConcurrency int      `mapstructure:"scrape_concurrency"`
+
+	// AddLabels configures the receiver to add human-readable labels to metrics using the Oxide API.
+	AddLabels bool `mapstructure:"add_labels"`
 }
 
 func (cfg *Config) Validate() error {


### PR DESCRIPTION
OxQL provides uuid labels for silos, projects, etc., but these aren't very useful for metrics queries: the user has to look up the uuid for each silo/project of interest. This patch adds the option to fetch silo and project metadata from the api and enrich labels where appropriate. We should support this in the api instead eventually, but it's quicker to add here for now.