### PR TITLE
Make query look back configurable.

### DIFF
--- a/config.go
+++ b/config.go
@@ -15,7 +15,12 @@ type Config struct {
 	MetricPatterns    []string `mapstructure:"metric_patterns"`
 	ScrapeConcurrency int      `mapstructure:"scrape_concurrency"`
 
-	// AddLabels configures the receiver to add human-readable labels to metrics using the Oxide API.
+	// QueryLookback configures the lookback interval of queries
+	// sent to the Oxide API.
+	QueryLookback string `mapstructure:"query_lookback"`
+
+	// AddLabels configures the receiver to add human-readable labels to
+	// metrics using the Oxide API.
 	AddLabels bool `mapstructure:"add_labels"`
 }
 

--- a/factory.go
+++ b/factory.go
@@ -25,6 +25,7 @@ func createDefaultConfig() component.Config {
 	return &Config{
 		MetricPatterns:    []string{".*"},
 		ScrapeConcurrency: 25,
+		QueryLookback:     "5m",
 	}
 }
 

--- a/scraper.go
+++ b/scraper.go
@@ -131,7 +131,7 @@ func (s *oxideScraper) Scrape(ctx context.Context) (pmetric.Metrics, error) {
 	latencies := make([]time.Duration, len(s.metricNames))
 
 	for idx, metricName := range s.metricNames {
-		query := fmt.Sprintf("get %s | filter timestamp > @now() - %dm | last 1", metricName, 15)
+		query := fmt.Sprintf("get %s | filter timestamp > @now() - %s | last 1", metricName, s.cfg.QueryLookback)
 		group.Go(func() error {
 			goroStartTime := time.Now()
 			result, err := s.client.SystemTimeseriesQuery(ctx, oxide.SystemTimeseriesQueryParams{


### PR DESCRIPTION
Rather than a fixed query lookback interval of 15m, make the lookback configurable with a reasonable default.