### PR TITLE
Optionally add silo utilization metrics.

### DIFF
--- a/collector/config.example.yaml
+++ b/collector/config.example.yaml
@@ -8,6 +8,8 @@ receivers:
     - virtual_machine:.*
     - virtual_disk:.*
     - hardware_component:.*
+    add_labels: true
+    add_utilization_metrics: true
     collection_interval: 60s
 
 processors:

--- a/config.go
+++ b/config.go
@@ -23,6 +23,10 @@ type Config struct {
 	// metrics using the Oxide API.
 	AddLabels bool `mapstructure:"add_labels"`
 
+	// AddUtilizationMetrics configures the receiver to add silo utilization
+	// metrics (cpu, memory, disk) with provisioned and allocated values.
+	AddUtilizationMetrics bool `mapstructure:"add_utilization_metrics"`
+
 	// InsecureSkipVerify configures the receiver to skip TLS certificate
 	// verification when connecting to the Oxide API.
 	InsecureSkipVerify bool `mapstructure:"insecure_skip_verify"`


### PR DESCRIPTION
Nexus exposes silo utilization (provisioned and allocated) via the API, but these values aren't currently available through OxQL. This patch optionally adds derived silo utilization metrics through Nexus. If these turn out to be useful, we'll implement this in OxQL and deprecate the derived metrics here later on.