### PR TITLE
Add docker-compose example for guides.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ Create a `collector/config.yaml` file with your collector configuration, or copy
 ./dist/otelcol-oxide --config collector/config.yaml
 ```
 
+If using the default configuration, you can check metrics in Prometheus format at `http://localhost:9091/metrics`.
+
+### Running the Collector with Docker Compose
+
+We provide an example Dockerfile and Docker Compose manifest to run the Collector, along with a Prometheus instance to persist metrics. Note: the Docker Compose manifest doesn't mount your Oxide configuration file, so you can't authenticate using Oxide profiles. Instead, either set the `OXIDE_HOST` and `OXIDE_TOKEN` environment variables, or add authentication details to your OpenTelemetry configuration file.
+
+```bash
+./dist/otelcol-oxide --config collector/config.yaml
+docker compose -f example/docker-compose.yaml up
+```
+
+Once the example is running, you can access the Prometheus instance at http://localhost:9090.
+
 ## Development
 
 ### Running Tests

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,0 +1,24 @@
+# Build stage
+FROM golang:1.25-alpine AS builder
+
+RUN apk add --no-cache git make
+
+WORKDIR /src
+
+# Copy the entire source tree (needed for the replace directive)
+COPY . .
+
+# Build the collector using existing make target
+RUN make build-collector
+
+# Runtime stage
+FROM alpine:3.21
+
+RUN apk add --no-cache ca-certificates
+
+COPY --from=builder /src/dist/otelcol-oxide /otelcol-oxide
+
+EXPOSE 9091 8888
+
+ENTRYPOINT ["/otelcol-oxide"]
+CMD ["--config", "/etc/otelcol/config.yaml"]

--- a/example/docker-compose.yaml
+++ b/example/docker-compose.yaml
@@ -1,0 +1,26 @@
+services:
+  otelcol:
+    build:
+      context: ..
+      dockerfile: example/Dockerfile
+    environment:
+    - OXIDE_HOST=${OXIDE_HOST}
+    - OXIDE_TOKEN=${OXIDE_TOKEN}
+    volumes:
+    - ../collector/config.yaml:/etc/otelcol/config.yaml:ro
+    ports:
+    - "9091:9091"
+    - "8888:8888"
+
+  prometheus:
+    image: prom/prometheus:v3.8.0
+    volumes:
+    - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    - prometheus_data:/prometheus
+    ports:
+    - "9090:9090"
+    depends_on:
+    - otelcol
+
+volumes:
+  prometheus_data:

--- a/example/prometheus.yml
+++ b/example/prometheus.yml
@@ -1,0 +1,14 @@
+global:
+  scrape_interval: 60s
+  metric_name_escaping_scheme: underscores
+
+scrape_configs:
+- job_name: otelcol
+  static_configs:
+  - targets:
+    - otelcol:9091
+
+- job_name: otelcol-internal
+  static_configs:
+  - targets:
+    - otelcol:8888


### PR DESCRIPTION
Add an example dockerfile, and a docker compose manifest to run the collector alongside a prometheus instance.