### PR TITLE
Update to oxide.go@main to support new histogram shape.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.139.0
-	github.com/oxidecomputer/oxide.go v0.7.0
+	github.com/oxidecomputer/oxide.go v0.7.1-0.20251212183218-71fff1ff0f2a
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.45.0
 	go.opentelemetry.io/collector/consumer v1.45.0

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.139.0
 github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.139.0/go.mod h1:VfA8xHz4xg7Fyj5bBsCDbOO3iVYzDn9wP/QFsjcAE5c=
 github.com/oxidecomputer/oxide.go v0.7.0 h1:ZRxH3vSgwZys/dsQthphW4o57xp0BivUCkND18b5nr4=
 github.com/oxidecomputer/oxide.go v0.7.0/go.mod h1:e/Azkl4nFUrsdsJ113siW/ZNUQkiG539e4i7a6GEcD8=
+github.com/oxidecomputer/oxide.go v0.7.1-0.20251212183218-71fff1ff0f2a h1:mUFdftMZZi5KFA4j1e4aSRMPgToHSJI1eZ0ZKjezjus=
+github.com/oxidecomputer/oxide.go v0.7.1-0.20251212183218-71fff1ff0f2a/go.mod h1:eYMtxTV8TtcQtcO5ed55vECnC/LCPEf3LFtZDial8sM=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/scraper_test.go
+++ b/scraper_test.go
@@ -466,18 +466,9 @@ func TestAddHistogram(t *testing.T) {
 									oxide.Distributionint64{
 										Bins:   []int{0, 1, 2},
 										Counts: []int{1, 2, 3},
-										P50: oxide.Quantile{
-											MarkerHeights: []float64{0.0, 1.0, 1.5, 1.8, 2.0},
-											P:             0.5,
-										},
-										P90: oxide.Quantile{
-											MarkerHeights: []float64{0.0, 1.0, 1.9, 1.95, 2.0},
-											P:             0.9,
-										},
-										P99: oxide.Quantile{
-											MarkerHeights: []float64{0.0, 1.0, 1.99, 1.995, 2.0},
-											P:             0.99,
-										},
+										P50:    1.5,
+										P90:    1.9,
+										P99:    1.99,
 									},
 								},
 							},
@@ -532,18 +523,9 @@ func TestAddHistogram(t *testing.T) {
 									oxide.Distributiondouble{
 										Bins:   []float64{0.0, 1.0, 2.0},
 										Counts: []int{1, 2, 3},
-										P50: oxide.Quantile{
-											MarkerHeights: []float64{0.0, 1.0, 1.5, 1.8, 2.0},
-											P:             0.5,
-										},
-										P90: oxide.Quantile{
-											MarkerHeights: []float64{0.0, 1.0, 1.9, 1.95, 2.0},
-											P:             0.9,
-										},
-										P99: oxide.Quantile{
-											MarkerHeights: []float64{0.0, 1.0, 1.99, 1.995, 2.0},
-											P:             0.99,
-										},
+										P50:    1.5,
+										P90:    1.9,
+										P99:    1.99,
 									},
 								},
 							},


### PR DESCRIPTION
The shape of the histogram api response is changing in r18. Update to oxide.go@main to support the new format.