### PR TITLE
Rename repo to opentelemetry-collector-components.

### DIFF
--- a/collector/manifest.yaml
+++ b/collector/manifest.yaml
@@ -40,7 +40,8 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.145.0
 
   # Add the Oxide receiver.
-  - gomod: github.com/oxidecomputer/oxidereceiver v0.1.0
+  - gomod: github.com/oxidecomputer/opentelemetry-collector-components v0.1.0
+    import: github.com/oxidecomputer/opentelemetry-collector-components/receiver/oxidemetricsreceiver
 
 connectors:
   - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.145.0
@@ -53,4 +54,4 @@ providers:
   - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.51.0
 
 replaces:
-  - github.com/oxidecomputer/oxidereceiver => ..
+  - github.com/oxidecomputer/opentelemetry-collector-components => ..

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/oxidecomputer/oxidereceiver
+module github.com/oxidecomputer/opentelemetry-collector-components
 
 go 1.25.0
 

--- a/receiver/oxidemetricsreceiver/config.go
+++ b/receiver/oxidemetricsreceiver/config.go
@@ -1,4 +1,4 @@
-package oxidereceiver
+package oxidemetricsreceiver
 
 import (
 	"fmt"

--- a/receiver/oxidemetricsreceiver/config_test.go
+++ b/receiver/oxidemetricsreceiver/config_test.go
@@ -1,4 +1,4 @@
-package oxidereceiver
+package oxidemetricsreceiver
 
 import (
 	"testing"

--- a/receiver/oxidemetricsreceiver/factory.go
+++ b/receiver/oxidemetricsreceiver/factory.go
@@ -1,4 +1,4 @@
-package oxidereceiver
+package oxidemetricsreceiver
 
 import (
 	"context"

--- a/receiver/oxidemetricsreceiver/factory_test.go
+++ b/receiver/oxidemetricsreceiver/factory_test.go
@@ -1,4 +1,4 @@
-package oxidereceiver
+package oxidemetricsreceiver
 
 import (
 	"context"

--- a/receiver/oxidemetricsreceiver/scraper.go
+++ b/receiver/oxidemetricsreceiver/scraper.go
@@ -1,4 +1,4 @@
-package oxidereceiver
+package oxidemetricsreceiver
 
 import (
 	"context"
@@ -74,7 +74,9 @@ func (s *oxideScraper) Start(ctx context.Context, _ component.Host) error {
 
 	s.logger.Info("collecting metrics", zap.Any("metrics", metricNames))
 
-	meter := s.settings.MeterProvider.Meter("github.com/oxidecomputer/oxidereceiver")
+	meter := s.settings.MeterProvider.Meter(
+		"github.com/oxidecomputer/opentelemetry-collector-components/receiver/oxidemetricsreceiver",
+	)
 
 	s.apiRequestDuration, err = meter.Float64Gauge(
 		"oxide_receiver.api_request.duration",

--- a/receiver/oxidemetricsreceiver/scraper_test.go
+++ b/receiver/oxidemetricsreceiver/scraper_test.go
@@ -1,4 +1,4 @@
-package oxidereceiver
+package oxidemetricsreceiver
 
 import (
 	"testing"


### PR DESCRIPTION
Fix import paths, and adopt the conventional directory structure for otel components, nesting the oxide metrics receiver within receivers/.