### PR TITLE
Fix build on linux.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ test:
 	go test -v ./...
 
 build-collector:
-	go tool builder --config collector/manifest.yaml
+	CGO_ENABLED=0 go tool builder --config collector/manifest.yaml
 
 clean:
 	@echo "Cleaning build artifacts..."


### PR DESCRIPTION
Disable CGO so that we don't depend on dynamically linked shared libraries that aren't available in, e.g., alpine.