### PR TITLE
Disable CGO throughout.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
     - run: go tool builder --config collector/manifest.yaml --skip-compilation
     - run: cd dist && go build -trimpath -o otelcol-oxide .
       env:
+        CGO_ENABLED: "0"
         GOOS: ${{ matrix.goos }}
         GOARCH: ${{ matrix.goarch }}
 


### PR DESCRIPTION
We fixed linking for local builds in #27, but missed the CI path. This patch adds the missing fix.