### PR TITLE
Omit streaming estimates from histograms.

### DIFF
--- a/receiver/oxidemetricsreceiver/scraper.go
+++ b/receiver/oxidemetricsreceiver/scraper.go
@@ -242,11 +242,9 @@ func (s *oxideScraper) Scrape(ctx context.Context) (pmetric.Metrics, error) {
 
 					quantiles := sm.Metrics().AppendEmpty()
 					quantiles.SetName(fmt.Sprintf("%s:quantiles", table.Name))
-					quantileGauge := quantiles.SetEmptyGauge()
 
 					if err := addHistogram(
 						measure.DataPoints(),
-						quantileGauge,
 						table,
 						series,
 					); err != nil {
@@ -426,7 +424,6 @@ func enrichLabels(resource pcommon.Resource, silos map[string]string, projects m
 
 func addHistogram(
 	dataPoints pmetric.HistogramDataPointSlice,
-	quantileGauge pmetric.Gauge,
 	table oxide.OxqlTable,
 	series oxide.Timeseries,
 ) error {
@@ -463,14 +460,6 @@ func addHistogram(
 				}
 				dp.SetCount(uint64(total))
 				dp.SetTimestamp(pcommon.NewTimestampFromTime(timestamps[idx]))
-
-				addQuantiles(
-					quantileGauge,
-					distValue.P50,
-					distValue.P90,
-					distValue.P99,
-					dp.Timestamp(),
-				)
 			}
 		case *oxide.ValueArrayDoubleDistribution:
 			if len(timestamps) != len(v.Values) {
@@ -491,14 +480,6 @@ func addHistogram(
 				}
 				dp.SetCount(uint64(total))
 				dp.SetTimestamp(pcommon.NewTimestampFromTime(timestamps[idx]))
-
-				addQuantiles(
-					quantileGauge,
-					distValue.P50,
-					distValue.P90,
-					distValue.P99,
-					dp.Timestamp(),
-				)
 			}
 		default:
 			return fmt.Errorf(
@@ -574,23 +555,4 @@ func addPoint(dataPoints pmetric.NumberDataPointSlice, series oxide.Timeseries) 
 		}
 	}
 	return nil
-}
-
-// addQuantiles emits metrics for P50, P90, P99 quantile values. In addition
-// to histogram buckets and counts, OxQL exposes a set of predefined quantile
-// estimates using the P² algorithm, which we extract here.
-func addQuantiles(g pmetric.Gauge, p50, p90, p99 float64, timestamp pcommon.Timestamp) {
-	for _, q := range []struct {
-		p     float64
-		value float64
-	}{
-		{0.50, p50},
-		{0.90, p90},
-		{0.99, p99},
-	} {
-		p := g.DataPoints().AppendEmpty()
-		p.SetTimestamp(timestamp)
-		p.SetDoubleValue(q.value)
-		p.Attributes().PutDouble("quantile", q.p)
-	}
 }

--- a/receiver/oxidemetricsreceiver/scraper_test.go
+++ b/receiver/oxidemetricsreceiver/scraper_test.go
@@ -370,11 +370,10 @@ func TestAddHistogram(t *testing.T) {
 	table := oxide.OxqlTable{Name: "test_metric"}
 
 	for _, tc := range []struct {
-		name          string
-		series        oxide.Timeseries
-		wantMetrics   []pmetric.HistogramDataPoint
-		wantQuantiles []pmetric.NumberDataPoint
-		wantErr       string
+		name        string
+		series      oxide.Timeseries
+		wantMetrics []pmetric.HistogramDataPoint
+		wantErr     string
 	}{
 		{
 			name: "int: success",
@@ -409,29 +408,6 @@ func TestAddHistogram(t *testing.T) {
 					dp.SetCount(6) // 1+2+3
 					dp.ExplicitBounds().FromRaw([]float64{0, 1, 2})
 					dp.BucketCounts().FromRaw([]uint64{1, 2, 3})
-					return dp
-				}(),
-			},
-			wantQuantiles: []pmetric.NumberDataPoint{
-				func() pmetric.NumberDataPoint {
-					dp := pmetric.NewNumberDataPoint()
-					dp.SetTimestamp(pcommon.NewTimestampFromTime(now))
-					dp.SetDoubleValue(1.5)
-					dp.Attributes().PutDouble("quantile", 0.5)
-					return dp
-				}(),
-				func() pmetric.NumberDataPoint {
-					dp := pmetric.NewNumberDataPoint()
-					dp.SetTimestamp(pcommon.NewTimestampFromTime(now))
-					dp.SetDoubleValue(1.9)
-					dp.Attributes().PutDouble("quantile", 0.9)
-					return dp
-				}(),
-				func() pmetric.NumberDataPoint {
-					dp := pmetric.NewNumberDataPoint()
-					dp.SetTimestamp(pcommon.NewTimestampFromTime(now))
-					dp.SetDoubleValue(1.99)
-					dp.Attributes().PutDouble("quantile", 0.99)
 					return dp
 				}(),
 			},
@@ -472,29 +448,6 @@ func TestAddHistogram(t *testing.T) {
 					return dp
 				}(),
 			},
-			wantQuantiles: []pmetric.NumberDataPoint{
-				func() pmetric.NumberDataPoint {
-					dp := pmetric.NewNumberDataPoint()
-					dp.SetTimestamp(pcommon.NewTimestampFromTime(now))
-					dp.SetDoubleValue(1.5)
-					dp.Attributes().PutDouble("quantile", 0.5)
-					return dp
-				}(),
-				func() pmetric.NumberDataPoint {
-					dp := pmetric.NewNumberDataPoint()
-					dp.SetTimestamp(pcommon.NewTimestampFromTime(now))
-					dp.SetDoubleValue(1.9)
-					dp.Attributes().PutDouble("quantile", 0.9)
-					return dp
-				}(),
-				func() pmetric.NumberDataPoint {
-					dp := pmetric.NewNumberDataPoint()
-					dp.SetTimestamp(pcommon.NewTimestampFromTime(now))
-					dp.SetDoubleValue(1.99)
-					dp.Attributes().PutDouble("quantile", 0.99)
-					return dp
-				}(),
-			},
 		},
 		{
 			name: "unexpected type",
@@ -516,9 +469,8 @@ func TestAddHistogram(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			histogramDataPoints := pmetric.NewHistogramDataPointSlice()
-			quantileGauge := pmetric.NewGauge()
 
-			err := addHistogram(histogramDataPoints, quantileGauge, table, tc.series)
+			err := addHistogram(histogramDataPoints, table, tc.series)
 
 			if tc.wantErr != "" {
 				require.ErrorContains(t, err, tc.wantErr)
@@ -527,7 +479,6 @@ func TestAddHistogram(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Equal(t, len(tc.wantMetrics), histogramDataPoints.Len())
-			require.Equal(t, len(tc.wantQuantiles), quantileGauge.DataPoints().Len())
 
 			for idx, wantMetric := range tc.wantMetrics {
 				err := pmetrictest.CompareHistogramDataPoints(
@@ -535,14 +486,6 @@ func TestAddHistogram(t *testing.T) {
 					histogramDataPoints.At(idx),
 				)
 				require.NoError(t, err, "mismatch at index %d", idx)
-			}
-
-			for idx, wantQuantile := range tc.wantQuantiles {
-				err := pmetrictest.CompareNumberDataPoint(
-					wantQuantile,
-					quantileGauge.DataPoints().At(idx),
-				)
-				require.NoError(t, err, "mismatch at quantile index %d", idx)
 			}
 		})
 	}


### PR DESCRIPTION
OxQL distribution metrics include histogram buckets of counts, as well as streaming quantile estimates. For monitoring purposes, users should query histograms rather than streaming quantiles. Histograms can be converted to rates by subtracting counts over time, then used to estimate quantiles over arbitrary time ranges. Streaming quantiles can't be differenced, and always represent a quantile since the beginning of the epoch of the timeseries.

This patch omits streaming quantile estimates from the metrics receiver.