### PR TITLE
Bump oxide.go to latest.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ tool (
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.139.0
-	github.com/oxidecomputer/oxide.go v0.8.1-0.20260219202204-dfdb24eebe46
+	github.com/oxidecomputer/oxide.go v0.8.1-0.20260304174018-b0f8ba0c764c
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.45.0
 	go.opentelemetry.io/collector/component/componenttest v0.139.0

--- a/go.sum
+++ b/go.sum
@@ -491,8 +491,8 @@ github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJ
 github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
 github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
-github.com/oxidecomputer/oxide.go v0.8.1-0.20260219202204-dfdb24eebe46 h1:Z1tRLvbJ3ad9cGWFaknQClMpSDvDGwvI0U07gkg52Pk=
-github.com/oxidecomputer/oxide.go v0.8.1-0.20260219202204-dfdb24eebe46/go.mod h1:pL9BcSmHMyhR8Utxr2AcV6wG59OIrcSV3dNduIzGGdo=
+github.com/oxidecomputer/oxide.go v0.8.1-0.20260304174018-b0f8ba0c764c h1:DfIxEF0z8prXMmYYDuRa4gTUXPHZ+4EYb3pc4iKqg+A=
+github.com/oxidecomputer/oxide.go v0.8.1-0.20260304174018-b0f8ba0c764c/go.mod h1:pL9BcSmHMyhR8Utxr2AcV6wG59OIrcSV3dNduIzGGdo=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=

--- a/receiver/oxidemetricsreceiver/scraper.go
+++ b/receiver/oxidemetricsreceiver/scraper.go
@@ -467,12 +467,12 @@ func addHistogram(
 				dp.ExplicitBounds().FromRaw(bins)
 
 				counts := dp.BucketCounts()
-				total := 0
+				var total uint64
 				for _, count := range distValue.Counts {
-					counts.Append(uint64(count))
+					counts.Append(count)
 					total += count
 				}
-				dp.SetCount(uint64(total))
+				dp.SetCount(total)
 				dp.SetTimestamp(pcommon.NewTimestampFromTime(timestamps[idx]))
 			}
 		case *oxide.ValueArrayDoubleDistribution:
@@ -487,12 +487,12 @@ func addHistogram(
 				dp.ExplicitBounds().FromRaw(distValue.Bins)
 
 				counts := dp.BucketCounts()
-				total := 0
+				var total uint64
 				for _, count := range distValue.Counts {
-					counts.Append(uint64(count))
+					counts.Append(count)
 					total += count
 				}
-				dp.SetCount(uint64(total))
+				dp.SetCount(total)
 				dp.SetTimestamp(pcommon.NewTimestampFromTime(timestamps[idx]))
 			}
 		default:

--- a/receiver/oxidemetricsreceiver/scraper_test.go
+++ b/receiver/oxidemetricsreceiver/scraper_test.go
@@ -388,7 +388,7 @@ func TestAddHistogram(t *testing.T) {
 									Values: []oxide.Distributionint64{
 										{
 											Bins:   []int{0, 1, 2},
-											Counts: []int{1, 2, 3},
+											Counts: []uint64{1, 2, 3},
 											P50:    1.5,
 											P90:    1.9,
 											P99:    1.99,
@@ -425,7 +425,7 @@ func TestAddHistogram(t *testing.T) {
 									Values: []oxide.Distributiondouble{
 										{
 											Bins:   []float64{0.0, 1.0, 2.0},
-											Counts: []int{1, 2, 3},
+											Counts: []uint64{1, 2, 3},
 											P50:    1.5,
 											P90:    1.9,
 											P99:    1.99,


### PR DESCRIPTION
Pull in https://github.com/oxidecomputer/oxide.go/pull/390 to fix an integer overflow error on large metric values.