### PR TITLE
Add control plane health example dashboard panels.

### DIFF
--- a/example/grafana/dashboards/internal-resource-utilization.json
+++ b/example/grafana/dashboards/internal-resource-utilization.json
@@ -280,7 +280,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 24,
+        "w": 12,
         "x": 0,
         "y": 18
       },
@@ -305,7 +305,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (zone_type) (rate(zone:cpu_nsec_total{oxide_host=\"$oxide_host\",zone_type!=\"\",state=~\"sys|user\"}[$__rate_interval]))",
+          "expr": "sum by (zone_type) (rate(zone:cpu_nsec_total{oxide_host=\"$oxide_host\",sled_id=~\"$sled_id\",zone_type!=\"\",state=~\"sys|user\"}[$__rate_interval]))",
           "legendFormat": "{{zone_type}}",
           "range": true,
           "refId": "A"
@@ -374,9 +374,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 26
+        "w": 12,
+        "x": 12,
+        "y": 18
       },
       "id": 4,
       "options": {
@@ -399,13 +399,223 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "topk(20, sum by (zone_name) (rate(zone:cpu_nsec_total{oxide_host=\"$oxide_host\",state=~\"sys|user\"}[$__rate_interval])))",
+          "expr": "topk(20, sum by (zone_name) (rate(zone:cpu_nsec_total{oxide_host=\"$oxide_host\",sled_id=~\"$sled_id\",state=~\"sys|user\"}[$__rate_interval])))",
           "legendFormat": "{{zone_name}}",
           "range": true,
           "refId": "A"
         }
       ],
       "title": "Top zone CPU usage by zone name",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 35,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "unit": "ns",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": true,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (rate(zone:cpu_nsec_total{oxide_host=\"$oxide_host\",sled_id=~\"$sled_id\",zone_type!=\"propolis-server\",state=~\"sys|user\"}[$__rate_interval]))",
+          "legendFormat": "control plane",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (rate(zone:cpu_nsec_total{oxide_host=\"$oxide_host\",sled_id=~\"$sled_id\",zone_type=\"propolis-server\",state=~\"sys|user\"}[$__rate_interval]))",
+          "legendFormat": "user instances",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Control plane vs instance CPU",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 35,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "unit": "ns",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 26
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": true,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (zone_type) (rate(zone:cpu_nsec_total{oxide_host=\"$oxide_host\",sled_id=~\"$sled_id\",zone_name=~\"oxz_.*\",zone_type!=\"propolis-server\",zone_type!=\"\",state=~\"sys|user\"}[$__rate_interval]))",
+          "legendFormat": "{{zone_type}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum (rate(zone:cpu_nsec_total{oxide_host=\"$oxide_host\",sled_id=~\"$sled_id\",zone_name=\"oxz_switch\",state=~\"sys|user\"}[$__rate_interval]))",
+          "legendFormat": "switch",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Control plane CPU by zone type",
       "type": "timeseries"
     },
     {
@@ -428,45 +638,8 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "mode": "continuous-GrYlRd"
           },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "unit": "percentunit",
-          "min": 0,
-          "max": 1,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -476,28 +649,39 @@
                 "value": null
               }
             ]
-          }
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 10,
         "w": 12,
         "x": 0,
         "y": 35
       },
       "id": 8,
       "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
+        "displayMode": "basic",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
         },
-        "tooltip": {
-          "hideZeros": true,
-          "mode": "multi",
-          "sort": "desc"
+        "showUnfilled": true,
+        "valueMode": "text",
+        "namePlacement": "auto",
+        "sizing": "auto",
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "text": {
+          "valueSize": 14,
+          "titleSize": 14
         }
       },
       "targets": [
@@ -507,14 +691,15 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (sled_id) (zfs_pool:bytes_allocated{oxide_host=\"$oxide_host\",sled_id=~\"$sled_id\"}) / sum by (sled_id) (zfs_pool:bytes_total{oxide_host=\"$oxide_host\",sled_id=~\"$sled_id\"})",
+          "expr": "sort_desc(sum by (sled_id) (zfs_pool:bytes_allocated{oxide_host=\"$oxide_host\",sled_id=~\"$sled_id\"}) / sum by (sled_id) (zfs_pool:bytes_total{oxide_host=\"$oxide_host\",sled_id=~\"$sled_id\"}))",
           "legendFormat": "{{sled_id}}",
-          "range": true,
+          "instant": true,
+          "range": false,
           "refId": "A"
         }
       ],
       "title": "Pool allocated % by sled",
-      "type": "timeseries"
+      "type": "bargauge"
     },
     {
       "datasource": {
@@ -524,45 +709,8 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "mode": "continuous-GrYlRd"
           },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "unit": "percentunit",
-          "min": 0,
-          "max": 1,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -572,28 +720,39 @@
                 "value": null
               }
             ]
-          }
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 10,
         "w": 12,
         "x": 12,
         "y": 35
       },
       "id": 9,
       "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
+        "displayMode": "basic",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
         },
-        "tooltip": {
-          "hideZeros": true,
-          "mode": "multi",
-          "sort": "desc"
+        "showUnfilled": true,
+        "valueMode": "text",
+        "namePlacement": "auto",
+        "sizing": "auto",
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "text": {
+          "valueSize": 14,
+          "titleSize": 14
         }
       },
       "targets": [
@@ -603,14 +762,15 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "topk(10, zfs_pool:bytes_allocated{oxide_host=\"$oxide_host\",sled_id=~\"$sled_id\"} / zfs_pool:bytes_total{oxide_host=\"$oxide_host\",sled_id=~\"$sled_id\"})",
+          "expr": "sort_desc(topk(15, zfs_pool:bytes_allocated{oxide_host=\"$oxide_host\",sled_id=~\"$sled_id\"} / zfs_pool:bytes_total{oxide_host=\"$oxide_host\",sled_id=~\"$sled_id\"}))",
           "legendFormat": "{{pool_name}}",
-          "range": true,
+          "instant": true,
+          "range": false,
           "refId": "A"
         }
       ],
       "title": "Top pools by allocated %",
-      "type": "timeseries"
+      "type": "bargauge"
     },
     {
       "datasource": {
@@ -620,43 +780,8 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "mode": "continuous-GrYlRd"
           },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "unit": "bytes",
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -666,28 +791,37 @@
                 "value": null
               }
             ]
-          }
+          },
+          "unit": "bytes"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 10,
         "w": 12,
         "x": 0,
-        "y": 43
+        "y": 45
       },
       "id": 10,
       "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
+        "displayMode": "basic",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
         },
-        "tooltip": {
-          "hideZeros": true,
-          "mode": "multi",
-          "sort": "desc"
+        "showUnfilled": false,
+        "valueMode": "text",
+        "namePlacement": "auto",
+        "sizing": "auto",
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "text": {
+          "valueSize": 14,
+          "titleSize": 14
         }
       },
       "targets": [
@@ -697,14 +831,15 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum by (dataset_kind) (zfs_dataset:bytes_used{oxide_host=\"$oxide_host\",sled_id=~\"$sled_id\",dataset_kind!=\"\"})",
+          "expr": "sort_desc(topk(15, sum by (dataset_kind) (zfs_dataset:bytes_used{oxide_host=\"$oxide_host\",sled_id=~\"$sled_id\",dataset_kind!=\"\"})))",
           "legendFormat": "{{dataset_kind}}",
-          "range": true,
+          "instant": true,
+          "range": false,
           "refId": "A"
         }
       ],
       "title": "Dataset usage by kind",
-      "type": "timeseries"
+      "type": "bargauge"
     },
     {
       "datasource": {
@@ -714,43 +849,8 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "palette-classic"
+            "mode": "continuous-GrYlRd"
           },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "unit": "bytes",
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -760,28 +860,37 @@
                 "value": null
               }
             ]
-          }
+          },
+          "unit": "bytes"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 10,
         "w": 12,
         "x": 12,
-        "y": 43
+        "y": 45
       },
       "id": 11,
       "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
+        "displayMode": "basic",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
         },
-        "tooltip": {
-          "hideZeros": true,
-          "mode": "multi",
-          "sort": "desc"
+        "showUnfilled": false,
+        "valueMode": "text",
+        "namePlacement": "auto",
+        "sizing": "auto",
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "text": {
+          "valueSize": 14,
+          "titleSize": 14
         }
       },
       "targets": [
@@ -791,14 +900,15 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "topk(20, zfs_dataset:bytes_used{oxide_host=\"$oxide_host\",sled_id=~\"$sled_id\",dataset_kind!=\"\"})",
+          "expr": "sort_desc(topk(15, zfs_dataset:bytes_used{oxide_host=\"$oxide_host\",sled_id=~\"$sled_id\",dataset_kind!=\"\"}))",
           "legendFormat": "{{dataset_name}}",
-          "range": true,
+          "instant": true,
+          "range": false,
           "refId": "A"
         }
       ],
       "title": "Top datasets by usage",
-      "type": "timeseries"
+      "type": "bargauge"
     }
   ],
   "schemaVersion": 42,

--- a/example/grafana/dashboards/oxide-receiver-health.json
+++ b/example/grafana/dashboards/oxide-receiver-health.json
@@ -29,6 +29,114 @@
         "x": 0,
         "y": 0
       },
+      "id": 23,
+      "title": "Prometheus scrape health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "unit": "none",
+          "min": 0,
+          "max": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "up",
+          "legendFormat": "{{job}} {{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Scrape up by target",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
       "id": 10,
       "panels": [],
       "title": "Metrics receiver",
@@ -99,7 +207,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 1
+        "y": 10
       },
       "id": 4,
       "options": {
@@ -197,7 +305,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 1
+        "y": 10
       },
       "id": 1,
       "options": {
@@ -295,7 +403,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 1
+        "y": 10
       },
       "id": 2,
       "options": {
@@ -330,7 +438,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 9
+        "y": 18
       },
       "id": 11,
       "panels": [],
@@ -402,7 +510,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 10
+        "y": 19
       },
       "id": 5,
       "options": {
@@ -500,7 +608,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 10
+        "y": 19
       },
       "id": 6,
       "options": {
@@ -598,7 +706,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 10
+        "y": 19
       },
       "id": 7,
       "options": {
@@ -633,7 +741,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 18
+        "y": 27
       },
       "id": 13,
       "panels": [],
@@ -705,7 +813,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 19
+        "y": 28
       },
       "id": 14,
       "options": {
@@ -803,7 +911,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 19
+        "y": 28
       },
       "id": 15,
       "options": {
@@ -901,7 +1009,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 27
+        "y": 36
       },
       "id": 17,
       "options": {
@@ -959,7 +1067,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 27
+        "y": 36
       },
       "id": 18,
       "options": {
@@ -1080,7 +1188,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 35
+        "y": 44
       },
       "id": 19,
       "options": {
@@ -1158,7 +1266,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 35
+        "y": 44
       },
       "id": 20,
       "options": {
@@ -1275,7 +1383,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 43
+        "y": 52
       },
       "id": 22,
       "options": {
@@ -1314,7 +1422,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 51
+        "y": 60
       },
       "id": 12,
       "panels": [],
@@ -1366,7 +1474,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 52
+        "y": 61
       },
       "id": 3,
       "options": {


### PR DESCRIPTION
* Show total cpu use for control plane vs user workloads.
* Show cpu use for all control plane (i.e. non-propolis) zones.

Drive-by improvements:

* Convert zfs utilization stats from timeseries to bars.
* Add panel for prometheus scraper health.

h/t @hermanol