### PR TITLE
Metrics: refresh schemas periodically.

### DIFF
--- a/receiver/oxidemetricsreceiver/config.go
+++ b/receiver/oxidemetricsreceiver/config.go
@@ -3,6 +3,7 @@ package oxidemetricsreceiver
 import (
 	"fmt"
 	"regexp"
+	"time"
 
 	"go.opentelemetry.io/collector/scraper/scraperhelper"
 )
@@ -30,6 +31,10 @@ type Config struct {
 	// InsecureSkipVerify configures the receiver to skip TLS certificate
 	// verification when connecting to the Oxide API.
 	InsecureSkipVerify bool `mapstructure:"insecure_skip_verify"`
+
+	// SchemaRefreshInterval configures the interval at which the receiver refreshes the list of
+	// available metrics from the Oxide API.
+	SchemaRefreshInterval time.Duration `mapstructure:"schema_refresh_interval"`
 }
 
 func (cfg *Config) Validate() error {
@@ -38,5 +43,10 @@ func (cfg *Config) Validate() error {
 			return fmt.Errorf("invalid metric pattern %s: %w", pattern, err)
 		}
 	}
+
+	if cfg.SchemaRefreshInterval < 0 {
+		return fmt.Errorf("invalid schema refresh interval %s", cfg.SchemaRefreshInterval)
+	}
+
 	return nil
 }

--- a/receiver/oxidemetricsreceiver/factory.go
+++ b/receiver/oxidemetricsreceiver/factory.go
@@ -2,6 +2,7 @@ package oxidemetricsreceiver
 
 import (
 	"context"
+	"time"
 
 	"github.com/oxidecomputer/oxide.go/oxide"
 	"go.opentelemetry.io/collector/component"
@@ -23,9 +24,10 @@ func NewFactory() receiver.Factory {
 // createDefaultConfig creates the default configuration for the receiver.
 func createDefaultConfig() component.Config {
 	return &Config{
-		MetricPatterns:    []string{".*"},
-		ScrapeConcurrency: 16,
-		QueryLookback:     "5m",
+		MetricPatterns:        []string{".*"},
+		ScrapeConcurrency:     16,
+		QueryLookback:         "5m",
+		SchemaRefreshInterval: 5 * time.Minute,
 	}
 }
 

--- a/receiver/oxidemetricsreceiver/scraper.go
+++ b/receiver/oxidemetricsreceiver/scraper.go
@@ -26,7 +26,9 @@ type oxideScraper struct {
 	logger   *zap.Logger
 	host     string
 
-	metricNames []string
+	metricPatterns     []*regexp.Regexp
+	schemasRefreshedAt time.Time
+	metricNames        []string
 
 	apiRequestDuration metric.Float64Gauge
 	scrapeCount        metric.Int64Counter
@@ -54,7 +56,14 @@ func newOxideScraper(
 	}
 }
 
-func (s *oxideScraper) Start(ctx context.Context, _ component.Host) error {
+// ensureSchemas fetches metric schemas from the API if empty or stale. This ensures that the
+// receiver discovers changes in metric schemas over time.
+func (s *oxideScraper) ensureSchemas(ctx context.Context) error {
+	now := time.Now()
+	if len(s.metricNames) > 0 && s.schemasRefreshedAt.Add(s.cfg.SchemaRefreshInterval).After(now) {
+		return nil
+	}
+
 	schemas, err := s.client.SystemTimeseriesSchemaListAllPages(
 		ctx,
 		oxide.SystemTimeseriesSchemaListParams{},
@@ -63,6 +72,24 @@ func (s *oxideScraper) Start(ctx context.Context, _ component.Host) error {
 		return err
 	}
 
+	metricNames := []string{}
+	for _, schema := range schemas {
+		for _, regexp := range s.metricPatterns {
+			if regexp.MatchString(string(schema.TimeseriesName)) {
+				metricNames = append(metricNames, string(schema.TimeseriesName))
+			}
+		}
+	}
+
+	s.logger.Info("collecting metrics", zap.Any("metrics", metricNames))
+
+	s.metricNames = metricNames
+	s.schemasRefreshedAt = now
+
+	return nil
+}
+
+func (s *oxideScraper) Start(_ context.Context, _ component.Host) error {
 	regexps := []*regexp.Regexp{}
 	for _, pattern := range s.cfg.MetricPatterns {
 		regexp, err := regexp.Compile(pattern)
@@ -71,23 +98,13 @@ func (s *oxideScraper) Start(ctx context.Context, _ component.Host) error {
 		}
 		regexps = append(regexps, regexp)
 	}
-
-	metricNames := []string{}
-	for _, schema := range schemas {
-		for _, regexp := range regexps {
-			if regexp.MatchString(string(schema.TimeseriesName)) {
-				metricNames = append(metricNames, string(schema.TimeseriesName))
-			}
-		}
-	}
-	s.metricNames = metricNames
-
-	s.logger.Info("collecting metrics", zap.Any("metrics", metricNames))
+	s.metricPatterns = regexps
 
 	meter := s.settings.MeterProvider.Meter(
 		"github.com/oxidecomputer/opentelemetry-collector-components/receiver/oxidemetricsreceiver",
 	)
 
+	var err error
 	s.apiRequestDuration, err = meter.Float64Gauge(
 		"oxide_receiver.api_request.duration",
 		metric.WithDescription("Duration of API requests to the Oxide API"),
@@ -127,6 +144,10 @@ func (s *oxideScraper) Scrape(ctx context.Context) (pmetric.Metrics, error) {
 
 	var group errgroup.Group
 	group.SetLimit(s.cfg.ScrapeConcurrency)
+
+	if err := s.ensureSchemas(ctx); err != nil {
+		return metrics, fmt.Errorf("refreshing metric schemas: %+w", err)
+	}
 
 	type queryResult struct {
 		response *oxide.OxqlQueryResult


### PR DESCRIPTION
Refresh metrics schemas on an interval, so that we accommodate changes in oximeter without having to remember to restart the collector.