### PR TITLE
Bump oxide.go and handle null values.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ tool (
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.139.0
-	github.com/oxidecomputer/oxide.go v0.10.0
+	github.com/oxidecomputer/oxide.go v0.10.1-0.20260812160657-6f808ccc9ea4
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/collector/component v1.45.0
 	go.opentelemetry.io/collector/component/componenttest v0.139.0

--- a/go.sum
+++ b/go.sum
@@ -493,6 +493,8 @@ github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT9
 github.com/otiai10/mint v1.3.1/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/oxidecomputer/oxide.go v0.10.0 h1:4eGzt3OrN2jJJpXdsNnyd26D+zYAIIF7A9wswx+f4LM=
 github.com/oxidecomputer/oxide.go v0.10.0/go.mod h1:H8k5p7Eb5+jQGbWNmeiJcOQPUvR3ciwwBzWf7B24lNo=
+github.com/oxidecomputer/oxide.go v0.10.1-0.20260812160657-6f808ccc9ea4 h1:Ufcd/8cC8PgrvU8VtpwEylC3LecxLCQdX05XWpijenk=
+github.com/oxidecomputer/oxide.go v0.10.1-0.20260812160657-6f808ccc9ea4/go.mod h1:5LzOmh5FNkx0t8nXdC5Y4d5twM7beJx/YEfk/f/6rzs=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=

--- a/receiver/oxidemetricsreceiver/scraper.go
+++ b/receiver/oxidemetricsreceiver/scraper.go
@@ -499,6 +499,9 @@ func addHistogram(
 			)
 		}
 		for pointIdx, distValue := range v.Values {
+			if distValue == nil {
+				continue
+			}
 			if len(distValue.Bins) == 0 {
 				continue
 			}
@@ -544,6 +547,9 @@ func addHistogram(
 			)
 		}
 		for idx, distValue := range v.Values {
+			if distValue == nil {
+				continue
+			}
 			if len(distValue.Bins) == 0 {
 				continue
 			}
@@ -591,12 +597,17 @@ func addPoint(
 			)
 		}
 		for idx, intValue := range v.Values {
-			dp := dataPoints.AppendEmpty()
-			dp.SetTimestamp(pcommon.NewTimestampFromTime(timestamps[idx]))
-			if hasStartTimes {
-				dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTimes[idx]))
+			// OxQL can emit null values for metrics queries. We don't have an obvious way to
+			// represent these values in OTLP, and don't want to replace missing values with zero
+			// values, so simply omit the datapoint entirely in this case.
+			if intValue != nil {
+				dp := dataPoints.AppendEmpty()
+				dp.SetTimestamp(pcommon.NewTimestampFromTime(timestamps[idx]))
+				if hasStartTimes {
+					dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTimes[idx]))
+				}
+				dp.SetIntValue(int64(*intValue))
 			}
-			dp.SetIntValue(int64(intValue))
 		}
 	case *oxide.ValueArrayDouble:
 		if len(timestamps) != len(v.Values) {
@@ -607,12 +618,14 @@ func addPoint(
 			)
 		}
 		for idx, floatValue := range v.Values {
-			dp := dataPoints.AppendEmpty()
-			dp.SetTimestamp(pcommon.NewTimestampFromTime(timestamps[idx]))
-			if hasStartTimes {
-				dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTimes[idx]))
+			if floatValue != nil {
+				dp := dataPoints.AppendEmpty()
+				dp.SetTimestamp(pcommon.NewTimestampFromTime(timestamps[idx]))
+				if hasStartTimes {
+					dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTimes[idx]))
+				}
+				dp.SetDoubleValue(*floatValue)
 			}
-			dp.SetDoubleValue(floatValue)
 		}
 	case *oxide.ValueArrayBoolean:
 		if len(timestamps) != len(v.Values) {
@@ -623,16 +636,18 @@ func addPoint(
 			)
 		}
 		for idx, boolValue := range v.Values {
-			dp := dataPoints.AppendEmpty()
-			dp.SetTimestamp(pcommon.NewTimestampFromTime(timestamps[idx]))
-			if hasStartTimes {
-				dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTimes[idx]))
+			if boolValue != nil {
+				dp := dataPoints.AppendEmpty()
+				dp.SetTimestamp(pcommon.NewTimestampFromTime(timestamps[idx]))
+				if hasStartTimes {
+					dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTimes[idx]))
+				}
+				intValue := 0
+				if *boolValue {
+					intValue = 1
+				}
+				dp.SetIntValue(int64(intValue))
 			}
-			intValue := 0
-			if boolValue {
-				intValue = 1
-			}
-			dp.SetIntValue(int64(intValue))
 		}
 	default:
 		return fmt.Errorf("got unexpected metric value type %T", metricValue.Values.Value)

--- a/receiver/oxidemetricsreceiver/scraper_test.go
+++ b/receiver/oxidemetricsreceiver/scraper_test.go
@@ -160,7 +160,7 @@ func TestAddPoint(t *testing.T) {
 					Values: []oxide.Values{
 						{
 							Values: oxide.ValueArray{
-								Value: &oxide.ValueArrayInteger{Values: []int{42}},
+								Value: &oxide.ValueArrayInteger{Values: []*int{oxide.NewPointer(42)}},
 							},
 						},
 					},
@@ -184,7 +184,7 @@ func TestAddPoint(t *testing.T) {
 					Values: []oxide.Values{
 						{
 							Values: oxide.ValueArray{
-								Value: &oxide.ValueArrayInteger{Values: []int{42}},
+								Value: &oxide.ValueArrayInteger{Values: []*int{oxide.NewPointer(42)}},
 							},
 						},
 					},
@@ -210,7 +210,7 @@ func TestAddPoint(t *testing.T) {
 					Values: []oxide.Values{
 						{
 							Values: oxide.ValueArray{
-								Value: &oxide.ValueArrayDouble{Values: []float64{42.5}},
+								Value: &oxide.ValueArrayDouble{Values: []*float64{oxide.NewPointer(42.5)}},
 							},
 						},
 					},
@@ -236,7 +236,7 @@ func TestAddPoint(t *testing.T) {
 					Values: []oxide.Values{
 						{
 							Values: oxide.ValueArray{
-								Value: &oxide.ValueArrayBoolean{Values: []bool{true}},
+								Value: &oxide.ValueArrayBoolean{Values: []*bool{oxide.NewPointer(true)}},
 							},
 						},
 					},
@@ -262,7 +262,7 @@ func TestAddPoint(t *testing.T) {
 					Values: []oxide.Values{
 						{
 							Values: oxide.ValueArray{
-								Value: &oxide.ValueArrayString{Values: []string{"not a number"}},
+								Value: &oxide.ValueArrayString{Values: []*string{oxide.NewPointer("not a number")}},
 							},
 						},
 					},
@@ -382,13 +382,13 @@ func TestAddHistogram(t *testing.T) {
 			name: "int: success",
 			series: oxide.Timeseries{
 				Points: oxide.Points{
-					StartTimes: []time.Time{startTime},
-					Timestamps: []time.Time{now},
+					StartTimes: []time.Time{startTime, startTime},
+					Timestamps: []time.Time{now, now.Add(time.Second)},
 					Values: []oxide.Values{
 						{
 							Values: oxide.ValueArray{
 								Value: &oxide.ValueArrayIntegerDistribution{
-									Values: []oxide.Distributionint64{
+									Values: []*oxide.Distributionint64{
 										{
 											Bins:   []int{0, 1, 2},
 											Counts: []uint64{1, 2, 3},
@@ -396,6 +396,9 @@ func TestAddHistogram(t *testing.T) {
 											P90:    1.9,
 											P99:    1.99,
 										},
+										// Note: Add a nil value to ensure that it's dropped as
+										// expected.
+										nil,
 									},
 								},
 							},
@@ -419,13 +422,13 @@ func TestAddHistogram(t *testing.T) {
 			name: "double: success",
 			series: oxide.Timeseries{
 				Points: oxide.Points{
-					StartTimes: []time.Time{startTime},
-					Timestamps: []time.Time{now},
+					StartTimes: []time.Time{startTime, startTime},
+					Timestamps: []time.Time{now, now.Add(time.Second)},
 					Values: []oxide.Values{
 						{
 							Values: oxide.ValueArray{
 								Value: &oxide.ValueArrayDoubleDistribution{
-									Values: []oxide.Distributiondouble{
+									Values: []*oxide.Distributiondouble{
 										{
 											Bins:   []float64{0.0, 1.0, 2.0},
 											Counts: []uint64{1, 2, 3},
@@ -433,6 +436,7 @@ func TestAddHistogram(t *testing.T) {
 											P90:    1.9,
 											P99:    1.99,
 										},
+										nil,
 									},
 								},
 							},
@@ -461,7 +465,7 @@ func TestAddHistogram(t *testing.T) {
 					Values: []oxide.Values{
 						{
 							Values: oxide.ValueArray{
-								Value: &oxide.ValueArrayInteger{Values: []int{1, 2, 3}},
+								Value: &oxide.ValueArrayInteger{Values: []*int{oxide.NewPointer(1), oxide.NewPointer(2), oxide.NewPointer(3)}},
 							},
 						},
 					},


### PR DESCRIPTION
Previously, oxide.go represented null metric values as zero values. After fixing this in oxide.go, we now need to check for nil values in the metrics receiver. Because OTLP doesn't have an obvious way to represent timestamped null values, we simply skip them.