### PR TITLE
Metrics: fetch all measurements within query interval.

### DIFF
--- a/collector/config.window.example.yaml
+++ b/collector/config.window.example.yaml
@@ -1,0 +1,55 @@
+receivers:
+  oxide:
+    # Note: uncomment to configure Oxide API authentication. By default, the
+    # collector uses the $OXIDE_{PROFILE,HOST,TOKEN} environment variables.
+    # host: ${env:OXIDE_HOST}
+    # token: ${env:OXIDE_TOKEN}
+    metric_patterns:
+    - .*
+    query_mode: window
+    add_labels: true
+    add_utilization_metrics: true
+    collection_interval: 180s
+    scrape_concurrency: 4
+
+processors:
+  batch:
+
+  # Drop duplicate metrics.
+  #
+  # Metrics from the mwocp68 sensor are duplicated because hubris doesn't account for multiple sensor names within the component: https://github.com/oxidecomputer/hubris/issues/2634. Duplicate metrics cause prometheus remote write to drop the entire batch, so we drop the relevant metrics entirely until the upstream issue is resolved.
+  filter/hubris_2634:
+    error_mode: ignore
+    metrics:
+      datapoint:
+      - 'metric.name == "hardware_component:temperature" and attributes["component_kind"] == "mwocp68"'
+      - 'metric.name == "hardware_component:fan_speed" and attributes["component_kind"] == "mwocp68"'
+
+exporters:
+  prometheusremotewrite:
+    endpoint: "http://prometheus:9090/api/v1/write"
+    tls:
+      insecure: true
+    resource_to_telemetry_conversion:
+      enabled: true
+    timeout: 60s
+
+  file:
+    path: /var/lib/otelcol/metrics.jsonl
+
+service:
+  telemetry:
+    metrics:
+      level: detailed
+      readers:
+      - pull:
+          exporter:
+            prometheus:
+              host: 0.0.0.0
+              port: 8888
+
+  pipelines:
+    metrics:
+      receivers: [oxide]
+      processors: [filter/hubris_2634, batch]
+      exporters: [prometheusremotewrite, file]

--- a/example/docker-compose.window.yaml
+++ b/example/docker-compose.window.yaml
@@ -1,0 +1,16 @@
+# Remote write example. Use with:
+#   docker compose -f docker-compose.yaml -f docker-compose.window.yaml up
+
+services:
+  otelcol:
+    volumes:
+    - ../collector/config.window.example.yaml:/etc/otelcol/config.yaml:ro
+    - otelcol_data:/var/lib/otelcol
+
+  prometheus:
+    command:
+    - --config.file=/etc/prometheus/prometheus.yml
+    - --web.enable-remote-write-receiver
+    volumes:
+    - ./prometheus.window.yml:/etc/prometheus/prometheus.yml:ro
+    - prometheus_data:/prometheus

--- a/example/prometheus.window.yml
+++ b/example/prometheus.window.yml
@@ -1,0 +1,13 @@
+global:
+  metric_name_escaping_scheme: underscores
+
+# Allow prometheus to accept out-of-order samples. If the collector restarts, we may push samples we already have, and we don't want this to fail the entire remote write batch.
+storage:
+  tsdb:
+    out_of_order_time_window: 1h
+
+scrape_configs:
+- job_name: otelcol-internal
+  static_configs:
+  - targets:
+    - otelcol:8888

--- a/receiver/oxidemetricsreceiver/config.go
+++ b/receiver/oxidemetricsreceiver/config.go
@@ -16,25 +16,65 @@ type Config struct {
 	MetricPatterns    []string `mapstructure:"metric_patterns"`
 	ScrapeConcurrency int      `mapstructure:"scrape_concurrency"`
 
-	// QueryLookback configures the lookback interval of queries
-	// sent to the Oxide API.
-	QueryLookback string `mapstructure:"query_lookback"`
+	// QueryMode configures the OxQL query config pattern. If `last`, we use `| last 1` to expose
+	// the most recent value of each series. This is the default behavior, and is appropriate for
+	// use with `prometheusexporter`, which only considers the most recent value for each series. If
+	// `window`, we query all metrics within the configured window, such that we retain the full
+	// fidelity of the OxQL metrics. This also allows us to query OxQL less often without losing
+	// resolution, and reduce load on OxQL.
+	QueryMode QueryMode `mapstructure:"query_mode"`
 
-	// AddLabels configures the receiver to add human-readable labels to
-	// metrics using the Oxide API.
+	// QueryLookback configures the lookback interval of queries sent to the Oxide API. Only used
+	// for the `last` query mode. Defaults to 5m.
+	QueryLookback time.Duration `mapstructure:"query_lookback"`
+
+	// QueryOffset is the offset applied to the end of the query window, only used for the `window`
+	// query mode. Because samples can arrive in oximeter later than their recorded timestamp, we
+	// include an offset so that late-arriving samples aren't dropped. Defaults to 5m.
+	QueryOffset time.Duration `mapstructure:"query_offset"`
+
+	// MaxWindowSize is the longest allowed query window, only used for the `window` query mode. If
+	// the query window exceeds `MaxWindowSize`, e.g. to catch up after a restart or failed
+	// collection, we left-truncate to avoid overwhelming oximeter.
+	MaxWindowSize time.Duration `mapstructure:"max_window_size"`
+
+	// AddLabels configures the receiver to add human-readable labels to metrics using the Oxide
+	// API.
 	AddLabels bool `mapstructure:"add_labels"`
 
-	// AddUtilizationMetrics configures the receiver to add silo utilization
-	// metrics (cpu, memory, disk) with provisioned and allocated values.
+	// AddUtilizationMetrics configures the receiver to add silo utilization metrics (cpu, memory,
+	// disk) with provisioned and allocated values.
 	AddUtilizationMetrics bool `mapstructure:"add_utilization_metrics"`
 
-	// InsecureSkipVerify configures the receiver to skip TLS certificate
-	// verification when connecting to the Oxide API.
+	// InsecureSkipVerify configures the receiver to skip TLS certificate verification when
+	// connecting to the Oxide API.
 	InsecureSkipVerify bool `mapstructure:"insecure_skip_verify"`
 
 	// SchemaRefreshInterval configures the interval at which the receiver refreshes the list of
 	// available metrics from the Oxide API.
 	SchemaRefreshInterval time.Duration `mapstructure:"schema_refresh_interval"`
+}
+
+type QueryMode string
+
+const (
+	QueryModeLast   QueryMode = "last"
+	QueryModeWindow QueryMode = "window"
+)
+
+func (m *QueryMode) UnmarshalText(text []byte) error {
+	switch mode := QueryMode(text); mode {
+	case QueryModeLast, QueryModeWindow:
+		*m = mode
+		return nil
+	default:
+		return fmt.Errorf(
+			"invalid query mode %q, expected %q or %q",
+			mode,
+			QueryModeLast,
+			QueryModeWindow,
+		)
+	}
 }
 
 func (cfg *Config) Validate() error {
@@ -46,6 +86,18 @@ func (cfg *Config) Validate() error {
 
 	if cfg.SchemaRefreshInterval < 0 {
 		return fmt.Errorf("invalid schema refresh interval %s", cfg.SchemaRefreshInterval)
+	}
+
+	if cfg.QueryLookback < 0 {
+		return fmt.Errorf("invalid query lookback %s", cfg.QueryOffset)
+	}
+
+	if cfg.QueryOffset < 0 {
+		return fmt.Errorf("invalid query offset %s", cfg.QueryOffset)
+	}
+
+	if cfg.MaxWindowSize < 0 {
+		return fmt.Errorf("invalid max window size %s", cfg.MaxWindowSize)
 	}
 
 	return nil

--- a/receiver/oxidemetricsreceiver/cumulative.go
+++ b/receiver/oxidemetricsreceiver/cumulative.go
@@ -1,0 +1,142 @@
+package oxidemetricsreceiver
+
+import (
+	"fmt"
+
+	"github.com/oxidecomputer/oxide.go/oxide"
+)
+
+// accumulate converts an OxQL timeseries from delta format to cumulative.
+//
+// TODO: optionally skip delta transformation of cumulative metrics in oximeter so that we don't
+// have to convert back to cumulative.
+func accumulate(series oxide.Timeseries) (oxide.Timeseries, error) {
+	if len(series.Points.Values) == 0 {
+		return series, nil
+	}
+	if series.Points.Values[0].MetricType == oxide.MetricTypeGauge {
+		return series, nil
+	}
+
+	timestamps := series.Points.Timestamps
+	startTimes := series.Points.StartTimes
+
+	for idx, pointValue := range series.Points.Values {
+		switch value := pointValue.Values.Value.(type) {
+		case *oxide.ValueArrayInteger:
+			var accumulator int
+			for valueIdx := range value.Values {
+				if value.Values[valueIdx] == nil {
+					continue
+				}
+				if valueIdx == 0 {
+					// If we're considering the 0th value, set the accumulator to the current value.
+					accumulator = *value.Values[valueIdx]
+				} else if startTimes[valueIdx] != timestamps[valueIdx-1] {
+					// If the series has reset, set the accumulator to the current value.
+					accumulator = *value.Values[valueIdx]
+				} else {
+					// Increment the accumulator.
+					accumulator += *value.Values[valueIdx]
+				}
+				*value.Values[valueIdx] = accumulator
+			}
+			series.Points.Values[idx].Values.Value = value
+		case *oxide.ValueArrayDouble:
+			var accumulator float64
+			for valueIdx := range value.Values {
+				if value.Values[valueIdx] == nil {
+					continue
+				}
+				if valueIdx == 0 {
+					accumulator = *value.Values[valueIdx]
+				} else if startTimes[valueIdx] != timestamps[valueIdx-1] {
+					accumulator = *value.Values[valueIdx]
+				} else {
+					accumulator += *value.Values[valueIdx]
+				}
+				*value.Values[valueIdx] = accumulator
+			}
+			series.Points.Values[idx].Values.Value = value
+		case *oxide.ValueArrayIntegerDistribution:
+			if len(value.Values) == 0 {
+				continue
+			}
+			var accumulator *oxide.Distributionint64
+			for valueIdx := range value.Values {
+				if value.Values[valueIdx] == nil {
+					continue
+				}
+				if valueIdx == 0 || accumulator == nil {
+					accumulator = cloneDistInt(value.Values[valueIdx])
+				} else if startTimes[valueIdx] != timestamps[valueIdx-1] {
+					accumulator = cloneDistInt(value.Values[valueIdx])
+				} else {
+					accumulateDistInt(accumulator, *value.Values[valueIdx])
+				}
+				value.Values[valueIdx] = cloneDistInt(accumulator)
+			}
+			series.Points.Values[idx].Values.Value = value
+		case *oxide.ValueArrayDoubleDistribution:
+			if len(value.Values) == 0 {
+				continue
+			}
+			var accumulator *oxide.Distributiondouble
+			for valueIdx := range value.Values {
+				if value.Values[valueIdx] == nil {
+					continue
+				}
+				if valueIdx == 0 || accumulator == nil {
+					accumulator = cloneDistDouble(value.Values[valueIdx])
+				} else if startTimes[valueIdx] != timestamps[valueIdx-1] {
+					accumulator = cloneDistDouble(value.Values[valueIdx])
+				} else {
+					accumulateDistDouble(accumulator, *value.Values[valueIdx])
+				}
+				value.Values[valueIdx] = cloneDistDouble(accumulator)
+			}
+			series.Points.Values[idx].Values.Value = value
+		default:
+			return series, fmt.Errorf("unexpected value type %T", pointValue.Values.Value)
+		}
+	}
+	return series, nil
+}
+
+func cloneDistInt(d *oxide.Distributionint64) *oxide.Distributionint64 {
+	counts := make([]uint64, len(d.Counts))
+	bins := make([]int, len(d.Bins))
+	copy(counts, d.Counts)
+	copy(bins, d.Bins)
+	return &oxide.Distributionint64{
+		Bins:   bins,
+		Counts: counts,
+	}
+}
+
+func cloneDistDouble(d *oxide.Distributiondouble) *oxide.Distributiondouble {
+	counts := make([]uint64, len(d.Counts))
+	bins := make([]float64, len(d.Bins))
+	copy(counts, d.Counts)
+	copy(bins, d.Bins)
+	return &oxide.Distributiondouble{
+		Bins:   bins,
+		Counts: counts,
+	}
+}
+
+func accumulateDistInt(cumulative *oxide.Distributionint64, delta oxide.Distributionint64) {
+	for binIdx := range delta.Counts {
+		if binIdx < len(cumulative.Counts) {
+			cumulative.Counts[binIdx] += delta.Counts[binIdx]
+		}
+	}
+}
+
+func accumulateDistDouble(cumulative *oxide.Distributiondouble, delta oxide.Distributiondouble) {
+	for binIdx := range delta.Counts {
+		if binIdx < len(cumulative.Counts) {
+			cumulative.Counts[binIdx] += delta.Counts[binIdx]
+		}
+	}
+}

--- a/receiver/oxidemetricsreceiver/cumulative_test.go
+++ b/receiver/oxidemetricsreceiver/cumulative_test.go
@@ -1,0 +1,267 @@
+package oxidemetricsreceiver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/oxidecomputer/oxide.go/oxide"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	t0 = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 = t0.Add(5 * time.Second)
+	t2 = t0.Add(10 * time.Second)
+	t3 = t0.Add(15 * time.Second)
+
+	epoch1 = time.Date(2025, 12, 1, 0, 0, 0, 0, time.UTC)
+	epoch2 = time.Date(2026, 1, 1, 0, 0, 12, 0, time.UTC)
+)
+
+func TestAccumulate_Integer(t *testing.T) {
+	series := oxide.Timeseries{
+		Points: oxide.Points{
+			Timestamps: []time.Time{t0, t1, t2},
+			StartTimes: []time.Time{epoch1, t0, t1},
+			Values: []oxide.Values{
+				{
+					MetricType: oxide.MetricTypeCumulative,
+					Values: oxide.ValueArray{
+						Value: &oxide.ValueArrayInteger{
+							Values: []*int{
+								oxide.NewPointer(100),
+								oxide.NewPointer(10),
+								oxide.NewPointer(15),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := accumulate(series)
+	require.NoError(t, err)
+
+	v := got.Points.Values[0].Values.Value.(*oxide.ValueArrayInteger)
+	require.Equal(t, []int{100, 110, 125}, derefSlice(v.Values))
+}
+
+func TestAccumulate_Integer_Reset(t *testing.T) {
+	series := oxide.Timeseries{
+		Points: oxide.Points{
+			Timestamps: []time.Time{t0, t1, t2, t3},
+			StartTimes: []time.Time{epoch1, t0, epoch2, t2},
+			Values: []oxide.Values{
+				{
+					MetricType: oxide.MetricTypeCumulative,
+					Values: oxide.ValueArray{
+						Value: &oxide.ValueArrayInteger{
+							Values: []*int{
+								oxide.NewPointer(100),
+								oxide.NewPointer(10),
+								oxide.NewPointer(50),
+								oxide.NewPointer(5),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := accumulate(series)
+	require.NoError(t, err)
+
+	v := got.Points.Values[0].Values.Value.(*oxide.ValueArrayInteger)
+	require.Equal(t, []int{100, 110, 50, 55}, derefSlice(v.Values))
+}
+
+func TestAccumulate_Double(t *testing.T) {
+	series := oxide.Timeseries{
+		Points: oxide.Points{
+			Timestamps: []time.Time{t0, t1, t2},
+			StartTimes: []time.Time{epoch1, t0, t1},
+			Values: []oxide.Values{
+				{
+					MetricType: oxide.MetricTypeDelta,
+					Values: oxide.ValueArray{
+						Value: &oxide.ValueArrayDouble{
+							Values: []*float64{
+								oxide.NewPointer(1.5),
+								oxide.NewPointer(0.5),
+								oxide.NewPointer(0.25),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := accumulate(series)
+	require.NoError(t, err)
+
+	v := got.Points.Values[0].Values.Value.(*oxide.ValueArrayDouble)
+	require.InDeltaSlice(t, []float64{1.5, 2.0, 2.25}, derefSlice(v.Values), 1e-9)
+}
+
+func TestAccumulate_Gauge_Passthrough(t *testing.T) {
+	series := oxide.Timeseries{
+		Points: oxide.Points{
+			Timestamps: []time.Time{t0, t1, t2},
+			Values: []oxide.Values{
+				{
+					MetricType: oxide.MetricTypeGauge,
+					Values: oxide.ValueArray{
+						Value: &oxide.ValueArrayDouble{
+							Values: []*float64{
+								oxide.NewPointer(1.0),
+								oxide.NewPointer(2.0),
+								oxide.NewPointer(3.0),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := accumulate(series)
+	require.NoError(t, err)
+
+	v := got.Points.Values[0].Values.Value.(*oxide.ValueArrayDouble)
+	require.Equal(t, []float64{1.0, 2.0, 3.0}, derefSlice(v.Values))
+}
+
+func TestAccumulate_SinglePoint(t *testing.T) {
+	series := oxide.Timeseries{
+		Points: oxide.Points{
+			Timestamps: []time.Time{t0},
+			StartTimes: []time.Time{epoch1},
+			Values: []oxide.Values{
+				{
+					MetricType: oxide.MetricTypeCumulative,
+					Values: oxide.ValueArray{
+						Value: &oxide.ValueArrayInteger{Values: []*int{oxide.NewPointer(42)}},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := accumulate(series)
+	require.NoError(t, err)
+
+	v := got.Points.Values[0].Values.Value.(*oxide.ValueArrayInteger)
+	require.Equal(t, []int{42}, derefSlice(v.Values))
+}
+
+func TestAccumulate_Empty(t *testing.T) {
+	series := oxide.Timeseries{
+		Points: oxide.Points{},
+	}
+
+	got, err := accumulate(series)
+	require.NoError(t, err)
+	require.Empty(t, got.Points.Values)
+}
+
+func TestAccumulate_IntegerDistribution(t *testing.T) {
+	series := oxide.Timeseries{
+		Points: oxide.Points{
+			Timestamps: []time.Time{t0, t1, t2},
+			StartTimes: []time.Time{epoch1, t0, t1},
+			Values: []oxide.Values{
+				{
+					MetricType: oxide.MetricTypeCumulative,
+					Values: oxide.ValueArray{
+						Value: &oxide.ValueArrayIntegerDistribution{
+							Values: []*oxide.Distributionint64{
+								{Bins: []int{10, 100}, Counts: []uint64{5, 3, 2}},
+								{Bins: []int{10, 100}, Counts: []uint64{1, 1, 0}},
+								{Bins: []int{10, 100}, Counts: []uint64{2, 0, 1}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := accumulate(series)
+	require.NoError(t, err)
+
+	v := got.Points.Values[0].Values.Value.(*oxide.ValueArrayIntegerDistribution)
+	require.Equal(t, []uint64{5, 3, 2}, v.Values[0].Counts)
+	require.Equal(t, []uint64{6, 4, 2}, v.Values[1].Counts)
+	require.Equal(t, []uint64{8, 4, 3}, v.Values[2].Counts)
+}
+
+func TestAccumulate_DoubleDistribution(t *testing.T) {
+	series := oxide.Timeseries{
+		Points: oxide.Points{
+			Timestamps: []time.Time{t0, t1},
+			StartTimes: []time.Time{epoch1, t0},
+			Values: []oxide.Values{
+				{
+					MetricType: oxide.MetricTypeCumulative,
+					Values: oxide.ValueArray{
+						Value: &oxide.ValueArrayDoubleDistribution{
+							Values: []*oxide.Distributiondouble{
+								{Bins: []float64{1.0, 10.0}, Counts: []uint64{10, 5, 3}},
+								{Bins: []float64{1.0, 10.0}, Counts: []uint64{2, 1, 0}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := accumulate(series)
+	require.NoError(t, err)
+
+	v := got.Points.Values[0].Values.Value.(*oxide.ValueArrayDoubleDistribution)
+	require.Equal(t, []uint64{10, 5, 3}, v.Values[0].Counts)
+	require.Equal(t, []uint64{12, 6, 3}, v.Values[1].Counts)
+}
+
+func TestAccumulate_Distribution_Reset(t *testing.T) {
+	series := oxide.Timeseries{
+		Points: oxide.Points{
+			Timestamps: []time.Time{t0, t1, t2},
+			StartTimes: []time.Time{epoch1, t0, epoch2},
+			Values: []oxide.Values{
+				{
+					MetricType: oxide.MetricTypeCumulative,
+					Values: oxide.ValueArray{
+						Value: &oxide.ValueArrayIntegerDistribution{
+							Values: []*oxide.Distributionint64{
+								{Bins: []int{10, 100}, Counts: []uint64{5, 3, 2}},
+								{Bins: []int{10, 100}, Counts: []uint64{1, 1, 0}},
+								{Bins: []int{10, 100}, Counts: []uint64{7, 0, 0}}, // reset
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := accumulate(series)
+	require.NoError(t, err)
+
+	v := got.Points.Values[0].Values.Value.(*oxide.ValueArrayIntegerDistribution)
+	require.Equal(t, []uint64{5, 3, 2}, v.Values[0].Counts)
+	require.Equal(t, []uint64{6, 4, 2}, v.Values[1].Counts)
+	require.Equal(t, []uint64{7, 0, 0}, v.Values[2].Counts) // fresh start
+}
+
+func derefSlice[T any](values []*T) []T {
+	out := make([]T, 0, len(values))
+	for _, value := range values {
+		out = append(out, *value)
+	}
+	return out
+}

--- a/receiver/oxidemetricsreceiver/factory.go
+++ b/receiver/oxidemetricsreceiver/factory.go
@@ -24,9 +24,12 @@ func NewFactory() receiver.Factory {
 // createDefaultConfig creates the default configuration for the receiver.
 func createDefaultConfig() component.Config {
 	return &Config{
+		ControllerConfig:      scraperhelper.NewDefaultControllerConfig(),
 		MetricPatterns:        []string{".*"},
-		ScrapeConcurrency:     16,
-		QueryLookback:         "5m",
+		ScrapeConcurrency:     8,
+		QueryMode:             QueryModeLast,
+		QueryLookback:         5 * time.Minute,
+		QueryOffset:           5 * time.Second,
 		SchemaRefreshInterval: 5 * time.Minute,
 	}
 }

--- a/receiver/oxidemetricsreceiver/factory_test.go
+++ b/receiver/oxidemetricsreceiver/factory_test.go
@@ -73,7 +73,6 @@ func TestDefaultConfig(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 
 	require.Equal(t, []string{".*"}, cfg.MetricPatterns)
-	require.Equal(t, 16, cfg.ScrapeConcurrency)
-	require.Equal(t, "5m", cfg.QueryLookback)
+	require.Equal(t, 8, cfg.ScrapeConcurrency)
 	require.False(t, cfg.InsecureSkipVerify, "InsecureSkipVerify should default to false")
 }

--- a/receiver/oxidemetricsreceiver/scraper.go
+++ b/receiver/oxidemetricsreceiver/scraper.go
@@ -26,13 +26,17 @@ type oxideScraper struct {
 	logger   *zap.Logger
 	host     string
 
+	maxWindowSize time.Duration
+
 	metricPatterns     []*regexp.Regexp
 	schemasRefreshedAt time.Time
 	metricNames        []string
+	lastWindowEnd      time.Time
 
-	apiRequestDuration metric.Float64Gauge
-	scrapeCount        metric.Int64Counter
-	scrapeDuration     metric.Float64Gauge
+	apiRequestDuration     metric.Float64Gauge
+	scrapeCount            metric.Int64Counter
+	scrapeDuration         metric.Float64Gauge
+	windowTruncateDuration metric.Float64Counter
 }
 
 func normalizeHost(raw string) string {
@@ -47,12 +51,18 @@ func newOxideScraper(
 	settings component.TelemetrySettings,
 	client *oxide.Client,
 ) *oxideScraper {
+	maxWindowSize := cfg.MaxWindowSize
+	if maxWindowSize == 0 {
+		maxWindowSize = 2 * cfg.CollectionInterval
+	}
+
 	return &oxideScraper{
-		client:   client,
-		settings: settings,
-		cfg:      cfg,
-		logger:   settings.Logger,
-		host:     normalizeHost(client.Host()),
+		client:        client,
+		settings:      settings,
+		cfg:           cfg,
+		logger:        settings.Logger,
+		host:          normalizeHost(client.Host()),
+		maxWindowSize: maxWindowSize,
 	}
 }
 
@@ -89,7 +99,7 @@ func (s *oxideScraper) ensureSchemas(ctx context.Context) error {
 	return nil
 }
 
-func (s *oxideScraper) Start(_ context.Context, _ component.Host) error {
+func (s *oxideScraper) Start(ctx context.Context, _ component.Host) error {
 	regexps := []*regexp.Regexp{}
 	for _, pattern := range s.cfg.MetricPatterns {
 		regexp, err := regexp.Compile(pattern)
@@ -132,11 +142,65 @@ func (s *oxideScraper) Start(_ context.Context, _ component.Host) error {
 		return fmt.Errorf("failed to create scrapeDuration gauge: %w", err)
 	}
 
+	s.windowTruncateDuration, err = meter.Float64Counter(
+		"oxide_receiver.scrape.window_truncate_duration",
+		metric.WithDescription(
+			"Duration the collection window was truncated due to exceeding the max window size",
+		),
+		metric.WithUnit("s"),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create windowTruncateDuration gauge: %w", err)
+	}
+	s.windowTruncateDuration.Add(ctx, 0)
+
 	return nil
 }
 
 func (s *oxideScraper) Shutdown(context.Context) error {
 	return nil
+}
+
+func buildLastQuery(metricName string, lookback time.Duration) string {
+	return fmt.Sprintf(
+		"get %s | filter timestamp > @now() - %dms | last 1",
+		metricName,
+		lookback.Milliseconds(),
+	)
+}
+
+func buildWindowQuery(metricName string, windowStart time.Time, windowEnd time.Time) string {
+	return fmt.Sprintf(
+		"get %s | filter timestamp > @%s | filter timestamp <= @%s",
+		metricName,
+		formatTimestamp(windowStart),
+		formatTimestamp(windowEnd),
+	)
+}
+
+func (s *oxideScraper) buildWindowBounds(
+	startTime time.Time,
+) (time.Time, time.Time, time.Duration) {
+	collectionInterval := s.cfg.CollectionInterval
+	maxWindowSize := s.maxWindowSize
+	lastWindowEnd := s.lastWindowEnd
+
+	windowEnd := startTime.Add(-s.cfg.QueryOffset)
+	var truncated time.Duration
+
+	if lastWindowEnd.IsZero() {
+		lastWindowEnd = windowEnd.Add(-collectionInterval)
+	} else if windowEnd.Sub(lastWindowEnd) > maxWindowSize {
+		lastWindowEnd = windowEnd.Add(-maxWindowSize)
+		truncated = lastWindowEnd.Sub(s.lastWindowEnd)
+	}
+	windowStart := lastWindowEnd
+
+	return windowStart, windowEnd, truncated
+}
+
+func formatTimestamp(t time.Time) string {
+	return t.UTC().Format("2006-01-02T15:04:05.000000000")
 }
 
 func (s *oxideScraper) Scrape(ctx context.Context) (pmetric.Metrics, error) {
@@ -157,13 +221,23 @@ func (s *oxideScraper) Scrape(ctx context.Context) (pmetric.Metrics, error) {
 	results := make([]queryResult, len(s.metricNames))
 
 	startTime := time.Now()
+	windowStart, windowEnd, truncated := s.buildWindowBounds(startTime)
+	if truncated > 0 {
+		s.logger.Warn(
+			"query window exceeds max_window_size, skipping ahead",
+			zap.Duration("truncated", truncated),
+			zap.Duration("max", s.maxWindowSize),
+		)
+		s.windowTruncateDuration.Add(ctx, truncated.Seconds())
+	}
 
 	for idx, metricName := range s.metricNames {
-		query := fmt.Sprintf(
-			"get %s | filter timestamp > @now() - %s | last 1",
-			metricName,
-			s.cfg.QueryLookback,
-		)
+		var query string
+		if s.cfg.QueryMode == QueryModeLast {
+			query = buildLastQuery(metricName, s.cfg.QueryLookback)
+		} else {
+			query = buildWindowQuery(metricName, windowStart, windowEnd)
+		}
 		group.Go(func() error {
 			queryStartTime := time.Now()
 			result, err := s.client.SystemTimeseriesQuery(ctx, oxide.SystemTimeseriesQueryParams{
@@ -199,10 +273,10 @@ func (s *oxideScraper) Scrape(ctx context.Context) (pmetric.Metrics, error) {
 					),
 				)
 			}
-
 			return nil
 		})
 	}
+
 	// We don't check the return value of Wait(). Instead, we accumulate error counts in the
 	// goroutine, and return a PartialScrapeError below if we observe >0 errors. Errors will be
 	// surfaced to users via the `scraper_errored_metric_points_total` metric, and collector logs
@@ -250,32 +324,32 @@ func (s *oxideScraper) Scrape(ctx context.Context) (pmetric.Metrics, error) {
 		}
 	}
 
+	rm := metrics.ResourceMetrics().AppendEmpty()
+	resource := rm.Resource()
+	resource.Attributes().PutStr("service.name", "oxide")
+	resource.Attributes().PutStr("oxide.host", s.host)
+	sm := rm.ScopeMetrics().AppendEmpty()
+
 	var parseErrors int
 	for _, result := range results {
 		if result.err != nil {
 			continue
 		}
+
 		for _, table := range result.response.Tables {
+			// Collect and validate non-empty timeseries, converting deltas to cumulative.
+			var timeseries []oxide.Timeseries
 			for _, series := range table.Timeseries {
-				rm := metrics.ResourceMetrics().AppendEmpty()
-				resource := rm.Resource()
-				resource.Attributes().PutStr("service.name", "oxide")
-				resource.Attributes().PutStr("oxide.host", s.host)
-
-				addLabels(series, resource)
-
-				enrichLabels(resource, siloToName, projectToName)
-
-				var sm pmetric.ScopeMetrics
-				if rm.ScopeMetrics().Len() == 0 {
-					sm = rm.ScopeMetrics().AppendEmpty()
-				} else {
-					sm = rm.ScopeMetrics().At(0)
+				series, err := accumulate(series)
+				if err != nil {
+					s.logger.Warn(
+						"failed to convert series to cumulative",
+						zap.String("metric", table.Name),
+						zap.Error(err),
+					)
+					parseErrors++
+					continue
 				}
-
-				m := sm.Metrics().AppendEmpty()
-
-				m.SetName(table.Name)
 
 				// All OxQL queries should return exactly one metric value, unless the query is
 				// empty. OxQL only returns multiple values when the query includes a join, which
@@ -292,23 +366,39 @@ func (s *oxideScraper) Scrape(ctx context.Context) (pmetric.Metrics, error) {
 					parseErrors++
 					continue
 				}
-				metricValue := series.Points.Values[0]
 
-				switch {
-				// Handle histograms.
-				case slices.Contains([]oxide.ValueArrayType{oxide.ValueArrayTypeIntegerDistribution, oxide.ValueArrayTypeDoubleDistribution}, metricValue.Values.Type()):
-					measure := m.SetEmptyHistogram()
-					// Always set aggregation temporality to cumulative. OxQL has both delta and
-					// cumulative counters, but both counter types use a cumulative value for their
-					// 0th observation. Because we add "| last 1" to all OxQL queries, all counter
-					// metrics are effectively of type cumulative for our purposes.
-					measure.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+				timeseries = append(timeseries, series)
+			}
 
+			if len(timeseries) == 0 {
+				continue
+			}
+
+			m := sm.Metrics().AppendEmpty()
+			m.SetName(table.Name)
+
+			// Determine the metric type from the first series. By this point, we've already ensured
+			// that timeseries and timeseries[0].Points.Values are each non-empty.
+			v0 := timeseries[0].Points.Values[0]
+
+			if slices.Contains(
+				[]oxide.ValueArrayType{
+					oxide.ValueArrayTypeIntegerDistribution,
+					oxide.ValueArrayTypeDoubleDistribution,
+				},
+				v0.Values.Type(),
+			) {
+				measure := m.SetEmptyHistogram()
+				measure.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+				dataPoints := measure.DataPoints()
+				for _, series := range timeseries {
 					if err := addHistogram(
-						measure.DataPoints(),
+						dataPoints,
 						table,
 						series,
-						metricValue,
+						series.Points.Values[0],
+						siloToName,
+						projectToName,
 					); err != nil {
 						s.logger.Warn(
 							"failed to add histogram metric",
@@ -317,38 +407,33 @@ func (s *oxideScraper) Scrape(ctx context.Context) (pmetric.Metrics, error) {
 						)
 						parseErrors++
 					}
-				// Handle scalar gauge.
-				case metricValue.MetricType == oxide.MetricTypeGauge:
-					measure := m.SetEmptyGauge()
-					if err := addPoint(measure.DataPoints(), series, metricValue); err != nil {
-						s.logger.Warn(
-							"failed to add gauge metric",
-							zap.String("metric", table.Name),
-							zap.Error(err),
-						)
-						parseErrors++
-					}
-
-				// Handle scalar counter.
-				default:
+				}
+			} else {
+				var dataPoints pmetric.NumberDataPointSlice
+				if v0.MetricType == oxide.MetricTypeGauge {
+					dataPoints = m.SetEmptyGauge().DataPoints()
+				} else {
 					measure := m.SetEmptySum()
-					// Always set aggregation temporality to cumulative. OxQL has both delta and
-					// cumulative counters, but both counter types use a cumulative value for their
-					// 0th observation. Because we add "| last 1" to all OxQL queries, all counter
-					// metrics are effectively of type cumulative for our purposes.
 					measure.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 					measure.SetIsMonotonic(true)
-
-					if err := addPoint(measure.DataPoints(), series, metricValue); err != nil {
+					dataPoints = measure.DataPoints()
+				}
+				for _, series := range timeseries {
+					if err := addPoint(
+						dataPoints,
+						series,
+						series.Points.Values[0],
+						siloToName,
+						projectToName,
+					); err != nil {
 						s.logger.Warn(
-							"failed to add sum metric",
+							"failed to add metric",
 							zap.String("metric", table.Name),
 							zap.Error(err),
 						)
 						parseErrors++
 					}
 				}
-
 			}
 		}
 	}
@@ -359,6 +444,11 @@ func (s *oxideScraper) Scrape(ctx context.Context) (pmetric.Metrics, error) {
 		}
 	}
 
+	// Record the end of the last (at least partially) successful collection.
+	if len(results) == 0 || queryErrors < len(results) {
+		s.lastWindowEnd = windowEnd
+	}
+
 	// Propagate partial errors to the collector machinery.
 	if queryErrors > 0 || parseErrors > 0 {
 		return metrics, scrapererror.NewPartialScrapeError(
@@ -366,6 +456,7 @@ func (s *oxideScraper) Scrape(ctx context.Context) (pmetric.Metrics, error) {
 			queryErrors+parseErrors,
 		)
 	}
+
 	return metrics, nil
 }
 
@@ -432,33 +523,33 @@ func addSiloUtilizationMetrics(
 	}
 }
 
-func addLabels(series oxide.Timeseries, resource pcommon.Resource) {
+func addLabels(series oxide.Timeseries, attrs pcommon.Map) {
 	for key, value := range series.Fields {
 		switch v := value.Value.(type) {
 		case *oxide.FieldValueString:
-			resource.Attributes().PutStr(key, v.Value)
+			attrs.PutStr(key, v.Value)
 		case *oxide.FieldValueI8:
-			resource.Attributes().PutInt(key, int64(*v.Value))
+			attrs.PutInt(key, int64(*v.Value))
 		case *oxide.FieldValueI16:
-			resource.Attributes().PutInt(key, int64(*v.Value))
+			attrs.PutInt(key, int64(*v.Value))
 		case *oxide.FieldValueI32:
-			resource.Attributes().PutInt(key, int64(*v.Value))
+			attrs.PutInt(key, int64(*v.Value))
 		case *oxide.FieldValueI64:
-			resource.Attributes().PutInt(key, int64(*v.Value))
+			attrs.PutInt(key, int64(*v.Value))
 		case *oxide.FieldValueU8:
-			resource.Attributes().PutInt(key, int64(*v.Value))
+			attrs.PutInt(key, int64(*v.Value))
 		case *oxide.FieldValueU16:
-			resource.Attributes().PutInt(key, int64(*v.Value))
+			attrs.PutInt(key, int64(*v.Value))
 		case *oxide.FieldValueU32:
-			resource.Attributes().PutInt(key, int64(*v.Value))
+			attrs.PutInt(key, int64(*v.Value))
 		case *oxide.FieldValueU64:
-			resource.Attributes().PutInt(key, int64(*v.Value))
+			attrs.PutInt(key, int64(*v.Value))
 		case *oxide.FieldValueUuid:
-			resource.Attributes().PutStr(key, v.Value)
+			attrs.PutStr(key, v.Value)
 		case *oxide.FieldValueIpAddr:
-			resource.Attributes().PutStr(key, v.Value)
+			attrs.PutStr(key, v.Value)
 		case *oxide.FieldValueBool:
-			resource.Attributes().PutBool(key, *v.Value)
+			attrs.PutBool(key, *v.Value)
 		default:
 			// Unreachable: if we get an unknown FieldValue variant, the SDK will return an error
 			// from UnmarshalJSON.
@@ -467,15 +558,15 @@ func addLabels(series oxide.Timeseries, resource pcommon.Resource) {
 	}
 }
 
-func enrichLabels(resource pcommon.Resource, silos map[string]string, projects map[string]string) {
-	if siloID, ok := resource.Attributes().Get("silo_id"); ok {
+func enrichLabels(attrs pcommon.Map, silos map[string]string, projects map[string]string) {
+	if siloID, ok := attrs.Get("silo_id"); ok {
 		if siloName, ok := silos[siloID.Str()]; ok {
-			resource.Attributes().PutStr("silo_name", siloName)
+			attrs.PutStr("silo_name", siloName)
 		}
 	}
-	if projectID, ok := resource.Attributes().Get("project_id"); ok {
+	if projectID, ok := attrs.Get("project_id"); ok {
 		if projectName, ok := projects[projectID.Str()]; ok {
-			resource.Attributes().PutStr("project_name", projectName)
+			attrs.PutStr("project_name", projectName)
 		}
 	}
 }
@@ -485,6 +576,8 @@ func addHistogram(
 	table oxide.OxqlTable,
 	series oxide.Timeseries,
 	metricValue oxide.Values,
+	silos map[string]string,
+	projects map[string]string,
 ) error {
 	timestamps := series.Points.Timestamps
 	startTimes := series.Points.StartTimes
@@ -512,18 +605,18 @@ func addHistogram(
 				dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTimes[pointIdx]))
 			}
 
-			// OxQL histograms model bins using a slice where each value represents the lower
-			// bound of the bin. A slice like [0, 10, 20, 30, 40] represents five bins: [0, 10),
-			// [10, 20), [20, 30), [30, 40), and [40, ∞). OpenTelemetry histograms represent
-			// buckets differently: each value represents the upper bound of the bin, and
-			// there's an implied bin that captures values greater than the final value of the
-			// slice. OpenTelemetry models the histogram above as [10, 20, 30, 40]. To make
-			// these representations match, we just drop the 0th OxQL bin and use the result as
-			// the OpenTelemetry bins. Note also that OxQL bins are closed at their lower bound
-			// and open at their upper bound. e.g. [0, 10). OpenTelemetry bins are open at the
-			// lower bound and closed at the upper bound: (0, 10]. It's not possible to
-			// reconstruct that boundary behavior while converting from OxQL histograms to
-			// OpenTelemetry histograms, so we accept the difference.
+			// OxQL histograms model bins using a slice where each value represents the lower bound
+			// of the bin. A slice like [0, 10, 20, 30, 40] represents five bins: [0, 10), [10, 20),
+			// [20, 30), [30, 40), and [40, ∞). OpenTelemetry histograms represent buckets
+			// differently: each value represents the upper bound of the bin, and there's an implied
+			// bin that captures values greater than the final value of the slice. OpenTelemetry
+			// models the histogram above as [10, 20, 30, 40]. To make these representations match,
+			// we just drop the 0th OxQL bin and use the result as the OpenTelemetry bins. Note also
+			// that OxQL bins are closed at their lower bound and open at their upper bound. e.g.
+			// [0, 10). OpenTelemetry bins are open at the lower bound and closed at the upper
+			// bound: (0, 10]. It's not possible to reconstruct that boundary behavior while
+			// converting from OxQL histograms to OpenTelemetry histograms, so we accept the
+			// difference.
 			bins := make([]float64, len(distValue.Bins)-1)
 			for binIdx, binValue := range distValue.Bins[1:] {
 				bins[binIdx] = float64(binValue)
@@ -537,6 +630,9 @@ func addHistogram(
 				total += count
 			}
 			dp.SetCount(total)
+
+			addLabels(series, dp.Attributes())
+			enrichLabels(dp.Attributes(), silos, projects)
 		}
 	case *oxide.ValueArrayDoubleDistribution:
 		if len(timestamps) != len(v.Values) {
@@ -568,6 +664,9 @@ func addHistogram(
 				total += count
 			}
 			dp.SetCount(total)
+
+			addLabels(series, dp.Attributes())
+			enrichLabels(dp.Attributes(), silos, projects)
 		}
 	default:
 		return fmt.Errorf(
@@ -583,6 +682,8 @@ func addPoint(
 	dataPoints pmetric.NumberDataPointSlice,
 	series oxide.Timeseries,
 	metricValue oxide.Values,
+	silos map[string]string,
+	projects map[string]string,
 ) error {
 	timestamps := series.Points.Timestamps
 	startTimes := series.Points.StartTimes
@@ -607,6 +708,8 @@ func addPoint(
 					dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTimes[idx]))
 				}
 				dp.SetIntValue(int64(*intValue))
+				addLabels(series, dp.Attributes())
+				enrichLabels(dp.Attributes(), silos, projects)
 			}
 		}
 	case *oxide.ValueArrayDouble:
@@ -625,6 +728,8 @@ func addPoint(
 					dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTimes[idx]))
 				}
 				dp.SetDoubleValue(*floatValue)
+				addLabels(series, dp.Attributes())
+				enrichLabels(dp.Attributes(), silos, projects)
 			}
 		}
 	case *oxide.ValueArrayBoolean:
@@ -647,6 +752,8 @@ func addPoint(
 					intValue = 1
 				}
 				dp.SetIntValue(int64(intValue))
+				addLabels(series, dp.Attributes())
+				enrichLabels(dp.Attributes(), silos, projects)
 			}
 		}
 	default:

--- a/receiver/oxidemetricsreceiver/scraper_test.go
+++ b/receiver/oxidemetricsreceiver/scraper_test.go
@@ -80,11 +80,11 @@ func TestAddLabels(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			resource := pcommon.NewResource()
+			attrs := pcommon.NewMap()
 
-			addLabels(tc.series, resource)
+			addLabels(tc.series, attrs)
 
-			require.Equal(t, tc.wantResource.Attributes().AsRaw(), resource.Attributes().AsRaw())
+			require.Equal(t, tc.wantResource.Attributes().AsRaw(), attrs.AsRaw())
 		})
 	}
 }
@@ -135,7 +135,7 @@ func TestEnrichLabels(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			enrichLabels(tc.resource, tc.silos, tc.projects)
+			enrichLabels(tc.resource.Attributes(), tc.silos, tc.projects)
 			require.Equal(t, tc.wantResource.Attributes().AsRaw(), tc.resource.Attributes().AsRaw())
 		})
 	}
@@ -274,7 +274,7 @@ func TestAddPoint(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			dataPoints := pmetric.NewNumberDataPointSlice()
 
-			err := addPoint(dataPoints, tc.series, tc.series.Points.Values[0])
+			err := addPoint(dataPoints, tc.series, tc.series.Points.Values[0], nil, nil)
 
 			if tc.wantErr != "" {
 				require.ErrorContains(t, err, tc.wantErr)
@@ -477,7 +477,14 @@ func TestAddHistogram(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			histogramDataPoints := pmetric.NewHistogramDataPointSlice()
 
-			err := addHistogram(histogramDataPoints, table, tc.series, tc.series.Points.Values[0])
+			err := addHistogram(
+				histogramDataPoints,
+				table,
+				tc.series,
+				tc.series.Points.Values[0],
+				nil,
+				nil,
+			)
 
 			if tc.wantErr != "" {
 				require.ErrorContains(t, err, tc.wantErr)


### PR DESCRIPTION
Rather than fetching only the most recent measuremnents with `| last 1`, use all measurements within the specified query interval. Because oximeter transforms cumulative metrics to deltas, other than the 0th value and values for resets, we transform values back to cumulative. This approach allows us to fetch oximeter metrics at the true sampling interval, while putting less load on oximeter: most of the load comes from fixed overhead, so it's cheaper to do a smaller number of queries over longer intervals than more frequent queries with `| last 1`.

Note: recording more than a single sample per series is only useful in a configuration that can push multiple samples downstream, such as the `prometheusremotewrite` exporter. Exporters that only consider the most recent sample don't benefit from this, so we leave the `| last 1` behavior available as the default.